### PR TITLE
Add basic styling and static asset support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # BRUNCLIENTPortal
+
+Minimal Node.js-based skeleton for a multilingual client portal.
+
+## Features
+- Three languages: Estonian, Finnish and English.
+- In-memory users with roles: admin, worker, client.
+- Simple login and dashboard demonstrating role-based access.
+
+## Usage
+```bash
+npm start
+```
+Visit <http://localhost:3000/?lang=en> (or `lang=et`, `lang=fi`).
+
+Sample credentials:
+- admin / admin123
+- worker / worker123
+- client / client123
+
+`npm test` simply starts the server for quick verification.

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,0 +1,8 @@
+{
+  "welcome": "Welcome",
+  "login_prompt": "Please log in",
+  "dashboard": "Dashboard",
+  "role_admin": "Administrator",
+  "role_worker": "Worker",
+  "role_client": "Client"
+}

--- a/locales/et.json
+++ b/locales/et.json
@@ -1,0 +1,8 @@
+{
+  "welcome": "Tere tulemast",
+  "login_prompt": "Palun logi sisse",
+  "dashboard": "Töölaud",
+  "role_admin": "Administraator",
+  "role_worker": "Töötaja",
+  "role_client": "Klient"
+}

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -1,0 +1,8 @@
+{
+  "welcome": "Tervetuloa",
+  "login_prompt": "Kirjaudu sisään",
+  "dashboard": "Hallintapaneeli",
+  "role_admin": "Ylläpitäjä",
+  "role_worker": "Työntekijä",
+  "role_client": "Asiakas"
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "brunclientportal",
+  "version": "1.0.0",
+  "description": "Minimal client portal skeleton",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node server.js"
+  },
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Client Portal</title>
+  <link rel="stylesheet" href="/style.css" />
+</head>
+<body>
+  <div class="login-box">
+    <h1 id="welcome"></h1>
+    <form method="POST" action="/login">
+      <label>Username:
+        <input name="username" />
+      </label>
+      <label>Password:
+        <input type="password" name="password" />
+      </label>
+      <button type="submit">Login</button>
+    </form>
+  </div>
+  <script>
+    const lang = new URLSearchParams(window.location.search).get('lang') || 'en';
+    fetch('/i18n?lang=' + lang).then(r => r.json()).then(dict => {
+      document.getElementById('welcome').textContent = dict.welcome;
+    });
+  </script>
+</body>
+</html>

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,54 @@
+body {
+  font-family: Arial, sans-serif;
+  background: #f5f5f5;
+  margin: 0;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.login-box {
+  background: #fff;
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  width: 300px;
+}
+
+h1 {
+  text-align: center;
+  margin-top: 0;
+  margin-bottom: 1.5rem;
+  color: #333;
+}
+
+label {
+  display: block;
+  margin-bottom: 0.5rem;
+  color: #555;
+}
+
+input {
+  width: 100%;
+  padding: 0.5rem;
+  margin-top: 0.25rem;
+  margin-bottom: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+button {
+  width: 100%;
+  padding: 0.75rem;
+  background: #007bff;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+button:hover {
+  background: #0056b3;
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,109 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const url = require('url');
+const querystring = require('querystring');
+const crypto = require('crypto');
+
+// Simple in-memory user store
+const users = {
+  admin: { password: 'admin123', role: 'admin' },
+  worker: { password: 'worker123', role: 'worker' },
+  client: { password: 'client123', role: 'client' }
+};
+
+const sessions = {}; // sessionId -> { username, role }
+
+function getTranslations(lang) {
+  const file = path.join(__dirname, 'locales', `${lang}.json`);
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch {
+    return JSON.parse(fs.readFileSync(path.join(__dirname, 'locales', 'en.json'), 'utf8'));
+  }
+}
+
+function serveFile(res, filePath, contentType = 'text/html') {
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.writeHead(404);
+      res.end('Not found');
+    } else {
+      res.writeHead(200, { 'Content-Type': contentType });
+      res.end(data);
+    }
+  });
+}
+
+function parseCookies(req) {
+  const list = {};
+  const rc = req.headers.cookie;
+  rc && rc.split(';').forEach(cookie => {
+    const parts = cookie.split('=');
+    list[parts.shift().trim()] = decodeURI(parts.join('='));
+  });
+  return list;
+}
+
+const server = http.createServer((req, res) => {
+  const parsedUrl = url.parse(req.url, true);
+  const lang = parsedUrl.query.lang || 'en';
+  if (req.method === 'GET') {
+    const staticPath = path.join(__dirname, 'public', parsedUrl.pathname);
+    if (parsedUrl.pathname !== '/' && fs.existsSync(staticPath)) {
+      const ext = path.extname(staticPath);
+      const types = {
+        '.css': 'text/css',
+        '.js': 'application/javascript',
+        '.html': 'text/html'
+      };
+      return serveFile(res, staticPath, types[ext] || 'application/octet-stream');
+    }
+  }
+
+  if (req.method === 'GET' && parsedUrl.pathname === '/') {
+    serveFile(res, path.join(__dirname, 'public', 'index.html'));
+  } else if (req.method === 'GET' && parsedUrl.pathname === '/i18n') {
+    const dict = getTranslations(lang);
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(dict));
+  } else if (req.method === 'POST' && parsedUrl.pathname === '/login') {
+    let body = '';
+    req.on('data', chunk => (body += chunk));
+    req.on('end', () => {
+      const data = querystring.parse(body);
+      const user = users[data.username];
+      if (user && user.password === data.password) {
+        const sid = crypto.randomBytes(16).toString('hex');
+        sessions[sid] = { username: data.username, role: user.role };
+        res.writeHead(302, {
+          'Set-Cookie': `sid=${sid}; HttpOnly`,
+          Location: '/dashboard'
+        });
+        res.end();
+      } else {
+        res.writeHead(401);
+        res.end('Invalid credentials');
+      }
+    });
+  } else if (req.method === 'GET' && parsedUrl.pathname === '/dashboard') {
+    const cookies = parseCookies(req);
+    const session = sessions[cookies.sid];
+    if (!session) {
+      res.writeHead(302, { Location: '/' });
+      res.end();
+      return;
+    }
+    const dict = getTranslations(lang);
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end(`<h1>${dict.dashboard}</h1><p>${dict['role_' + session.role]}</p>`);
+  } else {
+    res.writeHead(404);
+    res.end('Not found');
+  }
+});
+
+const port = 3000;
+server.listen(port, () => {
+  console.log(`Server running at http://localhost:${port}`);
+});


### PR DESCRIPTION
## Summary
- add stylesheet to polish login page appearance
- link login page to new styles and refine markup
- serve static assets from public directory for CSS delivery

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0d45e39f88332bd62c69912b70c99