### PR TITLE
Add FastAPI-based trip log backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
-# BRUNCLIENTPortal
+# Sõidupäeviku API
+
+Lihtne FastAPI teenus sõidupäeviku haldamiseks, mis toetab admini ja tavakasutaja rolle, sõidukite haldust ning GPS-koordinaatidega sõitude logimist.
+
+## Funktsionaalsus
+- **Autentimine**: OAuth2/JWT põhine sisselogimine. Vaikimisi luuakse käivitamisel kasutaja `admin` parooliga `admin123`.
+- **Rollid**: Admin näeb kõiki sõidukeid ja sõite ning saab hallata kasutajaid/veokeid. Tavakasutaja näeb ainult endaga seotud sõidukeid ja enda sõite.
+- **Sõidukid**: Admin saab luua sõidukeid, määrata odomeetri algnäidu ning siduda neid kasutajatega.
+- **Sõidud**: 
+  - Manuaalne lisamine koos alg- ja lõpp-odomeetri, GPS-koordinaatide ja töö/erakasutuse märkimisega.
+  - Nupupõhine voog: `/trips/start` avab sõidu automaatse alguse ajaga ja vajadusel GPS-koordinaatidega; `/trips/{id}/stop` lõpetab sõidu ning salvestab lõpu odomeetri ja asukoha.
+  - Algne odomeeter võetakse vaikimisi viimase lõpetatud sõidu lõpunäitust või sõiduki algseadistusest.
+- **Filtrid**: Sõitude päringus saab filtreerida kliendi järgi.
+
+## Kiirstart
+1. Paigalda sõltuvused:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+2. Käivita arendusserver:
+   ```bash
+   uvicorn app.main:app --reload
+   ```
+3. Ava Swagger UI aadressil `http://localhost:8000/docs` ja logi sisse `admin`/`admin123`.
+
+## API ülevaade
+- `POST /auth/login` – tagastab JWT access tokeni.
+- `POST /users` – (admin) loob uue kasutaja.
+- `POST /vehicles` – (admin) lisab sõiduki.
+- `POST /vehicles/{vehicle_id}/assign` – (admin) seob sõiduki kasutajaga.
+- `POST /vehicles/{vehicle_id}/odometer` – (admin) uuendab odomeetri algnäitu.
+- `GET /vehicles` – tagastab kõik või kasutajaga seotud sõidukid.
+- `POST /trips/manual` – lisab manuaalse sõidu.
+- `POST /trips/start` / `POST /trips/{id}/stop` – alustab ja lõpetab sõidu nupuvoolus.
+- `GET /trips?client=...` – loetleb sõidud, valikuline filtreerimine kliendi järgi.
+
+### Rollipõhine ligipääs
+- Admin: kõik sõidukid ja sõidud, halduspunktid kasutajatele ja sõidukitele.
+- Tavakasutaja: ainult talle määratud sõidukid, ainult enda loodud sõidud.
+
+### Andmemudelid
+- **Vehicle**: nimi, klient, `odometer_start`.
+- **Trip**: aeg, odomeetrid, GPS algus/lõpp, `trip_type` (business/personal), klient.
+
+### Märkused
+- Ära kasuta tootmises vaikimisi `SECRET_KEY` väärtust; uuenda see `app/auth.py` failis.
+- Andmed salvestatakse SQLite faili `app.db`.

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,77 @@
+from datetime import datetime, timedelta
+from typing import Optional
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+from sqlmodel import Session, select
+
+from app import models
+from app.database import get_session
+from app.schemas import TokenData
+
+SECRET_KEY = "change-me-in-production"
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 60 * 24
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return encoded_jwt
+
+
+def get_user_by_username(session: Session, username: str) -> Optional[models.User]:
+    statement = select(models.User).where(models.User.username == username)
+    return session.exec(statement).first()
+
+
+def authenticate_user(session: Session, username: str, password: str) -> Optional[models.User]:
+    user = get_user_by_username(session, username)
+    if not user or not verify_password(password, user.password_hash):
+        return None
+    return user
+
+
+async def get_current_user(
+    token: str = Depends(oauth2_scheme), session: Session = Depends(get_session)
+) -> models.User:
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        username: str = payload.get("sub")
+        role: str = payload.get("role")
+        user_id: int = payload.get("user_id")
+        if username is None or role is None or user_id is None:
+            raise credentials_exception
+        token_data = TokenData(username=username, role=models.Role(role), user_id=user_id)
+    except JWTError:
+        raise credentials_exception
+    user = get_user_by_username(session, token_data.username)
+    if user is None:
+        raise credentials_exception
+    return user
+
+
+def require_admin(user: models.User = Depends(get_current_user)) -> models.User:
+    if user.role != models.Role.admin:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin privileges required")
+    return user

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,15 @@
+from sqlmodel import SQLModel, create_engine, Session
+
+DATABASE_URL = "sqlite:///./app.db"
+engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
+
+
+def init_db() -> None:
+    import app.models  # noqa: F401
+
+    SQLModel.metadata.create_all(engine)
+
+
+def get_session() -> Session:
+    with Session(engine) as session:
+        yield session

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,267 @@
+from datetime import datetime
+from typing import List, Optional
+
+from fastapi import Depends, FastAPI, HTTPException, status
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.security import OAuth2PasswordRequestForm
+from sqlmodel import Session, select
+
+from app import auth, models, schemas
+from app.database import engine, get_session, init_db
+
+app = FastAPI(title="Sõidupäeviku API")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    init_db()
+    with Session(engine) as session:
+        ensure_admin_exists(session)
+
+
+def ensure_admin_exists(session: Session) -> None:
+    existing_admin = session.exec(select(models.User).where(models.User.role == models.Role.admin)).first()
+    if existing_admin:
+        return
+    admin_user = models.User(
+        username="admin",
+        password_hash=auth.get_password_hash("admin123"),
+        role=models.Role.admin,
+    )
+    session.add(admin_user)
+    session.commit()
+
+
+@app.post("/auth/login", response_model=schemas.Token)
+def login_for_access_token(
+    form_data: OAuth2PasswordRequestForm = Depends(), session: Session = Depends(get_session)
+):
+    user = auth.authenticate_user(session, form_data.username, form_data.password)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Incorrect username or password")
+    access_token = auth.create_access_token(
+        data={"sub": user.username, "role": user.role.value, "user_id": user.id}
+    )
+    return schemas.Token(access_token=access_token)
+
+
+@app.post("/users", response_model=schemas.UserRead)
+def create_user(
+    user_in: schemas.UserCreate,
+    session: Session = Depends(get_session),
+    admin: models.User = Depends(auth.require_admin),
+):
+    if auth.get_user_by_username(session, user_in.username):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Username already exists")
+    user = models.User(
+        username=user_in.username,
+        password_hash=auth.get_password_hash(user_in.password),
+        role=user_in.role,
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+@app.post("/vehicles", response_model=schemas.VehicleRead)
+def create_vehicle(
+    vehicle_in: schemas.VehicleCreate,
+    session: Session = Depends(get_session),
+    admin: models.User = Depends(auth.require_admin),
+):
+    vehicle = models.Vehicle(
+        name=vehicle_in.name,
+        client=vehicle_in.client,
+        odometer_start=vehicle_in.odometer_start,
+    )
+    session.add(vehicle)
+    session.commit()
+    session.refresh(vehicle)
+    return vehicle
+
+
+@app.get("/vehicles", response_model=List[schemas.VehicleRead])
+def list_vehicles(
+    session: Session = Depends(get_session), current_user: models.User = Depends(auth.get_current_user)
+):
+    if current_user.role == models.Role.admin:
+        statement = select(models.Vehicle)
+    else:
+        statement = (
+            select(models.Vehicle)
+            .join(models.UserVehicleLink)
+            .where(models.UserVehicleLink.user_id == current_user.id)
+        )
+    return list(session.exec(statement).all())
+
+
+@app.post("/vehicles/{vehicle_id}/assign")
+def assign_vehicle(
+    vehicle_id: int,
+    payload: schemas.VehicleAssign,
+    session: Session = Depends(get_session),
+    admin: models.User = Depends(auth.require_admin),
+):
+    vehicle = session.get(models.Vehicle, vehicle_id)
+    user = session.get(models.User, payload.user_id)
+    if not vehicle or not user:
+        raise HTTPException(status_code=404, detail="Vehicle or user not found")
+    link = session.exec(
+        select(models.UserVehicleLink)
+        .where(models.UserVehicleLink.user_id == user.id)
+        .where(models.UserVehicleLink.vehicle_id == vehicle.id)
+    ).first()
+    if not link:
+        session.add(models.UserVehicleLink(user_id=user.id, vehicle_id=vehicle.id))
+        session.commit()
+    return {"message": "Vehicle assigned"}
+
+
+@app.post("/vehicles/{vehicle_id}/odometer", response_model=schemas.VehicleRead)
+def update_vehicle_odometer(
+    vehicle_id: int,
+    payload: schemas.OdometerUpdate,
+    session: Session = Depends(get_session),
+    admin: models.User = Depends(auth.require_admin),
+):
+    vehicle = session.get(models.Vehicle, vehicle_id)
+    if not vehicle:
+        raise HTTPException(status_code=404, detail="Vehicle not found")
+    vehicle.odometer_start = payload.odometer_start
+    session.add(vehicle)
+    session.commit()
+    session.refresh(vehicle)
+    return vehicle
+
+
+def verify_vehicle_access(session: Session, user: models.User, vehicle_id: int) -> models.Vehicle:
+    vehicle = session.get(models.Vehicle, vehicle_id)
+    if not vehicle:
+        raise HTTPException(status_code=404, detail="Vehicle not found")
+    if user.role == models.Role.admin:
+        return vehicle
+    allowed = session.exec(
+        select(models.UserVehicleLink)
+        .where(models.UserVehicleLink.user_id == user.id)
+        .where(models.UserVehicleLink.vehicle_id == vehicle_id)
+    ).first()
+    if not allowed:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Vehicle not assigned to user")
+    return vehicle
+
+
+def get_last_odometer(session: Session, vehicle_id: int) -> float:
+    last_trip = session.exec(
+        select(models.Trip)
+        .where(models.Trip.vehicle_id == vehicle_id)
+        .where(models.Trip.end_odometer.is_not(None))
+        .order_by(models.Trip.end_time.desc())
+    ).first()
+    if last_trip and last_trip.end_odometer is not None:
+        return last_trip.end_odometer
+    vehicle = session.get(models.Vehicle, vehicle_id)
+    return vehicle.odometer_start if vehicle else 0
+
+
+@app.post("/trips/manual", response_model=schemas.TripRead)
+def create_manual_trip(
+    trip_in: schemas.TripManualCreate,
+    session: Session = Depends(get_session),
+    current_user: models.User = Depends(auth.get_current_user),
+):
+    vehicle = verify_vehicle_access(session, current_user, trip_in.vehicle_id)
+    start_odometer = trip_in.start_odometer or get_last_odometer(session, vehicle.id)
+    start_time = trip_in.start_time or datetime.utcnow()
+    if trip_in.end_odometer < start_odometer:
+        raise HTTPException(status_code=400, detail="End odometer cannot be lower than start")
+    trip = models.Trip(
+        vehicle_id=vehicle.id,
+        user_id=current_user.id,
+        start_time=start_time,
+        end_time=trip_in.end_time or datetime.utcnow(),
+        start_odometer=start_odometer,
+        end_odometer=trip_in.end_odometer,
+        start_lat=trip_in.start_lat,
+        start_lon=trip_in.start_lon,
+        end_lat=trip_in.end_lat,
+        end_lon=trip_in.end_lon,
+        trip_type=trip_in.trip_type,
+        client=trip_in.client,
+    )
+    session.add(trip)
+    session.commit()
+    session.refresh(trip)
+    return trip
+
+
+@app.post("/trips/start", response_model=schemas.TripRead)
+def start_trip(
+    payload: schemas.TripStart,
+    session: Session = Depends(get_session),
+    current_user: models.User = Depends(auth.get_current_user),
+):
+    vehicle = verify_vehicle_access(session, current_user, payload.vehicle_id)
+    start_odometer = payload.start_odometer or get_last_odometer(session, vehicle.id)
+    trip = models.Trip(
+        vehicle_id=vehicle.id,
+        user_id=current_user.id,
+        start_time=datetime.utcnow(),
+        start_odometer=start_odometer,
+        start_lat=payload.start_lat,
+        start_lon=payload.start_lon,
+        trip_type=payload.trip_type,
+        client=payload.client,
+    )
+    session.add(trip)
+    session.commit()
+    session.refresh(trip)
+    return trip
+
+
+@app.post("/trips/{trip_id}/stop", response_model=schemas.TripRead)
+def stop_trip(
+    trip_id: int,
+    payload: schemas.TripStop,
+    session: Session = Depends(get_session),
+    current_user: models.User = Depends(auth.get_current_user),
+):
+    trip = session.get(models.Trip, trip_id)
+    if not trip:
+        raise HTTPException(status_code=404, detail="Trip not found")
+    if current_user.role != models.Role.admin and trip.user_id != current_user.id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized to finish this trip")
+    if trip.end_time is not None:
+        raise HTTPException(status_code=400, detail="Trip already finished")
+    if payload.end_odometer < trip.start_odometer:
+        raise HTTPException(status_code=400, detail="End odometer cannot be lower than start")
+    trip.end_time = datetime.utcnow()
+    trip.end_odometer = payload.end_odometer
+    trip.end_lat = payload.end_lat
+    trip.end_lon = payload.end_lon
+    session.add(trip)
+    session.commit()
+    session.refresh(trip)
+    return trip
+
+
+@app.get("/trips", response_model=schemas.TripCollection)
+def list_trips(
+    client: Optional[str] = None,
+    session: Session = Depends(get_session),
+    current_user: models.User = Depends(auth.get_current_user),
+):
+    statement = select(models.Trip)
+    if current_user.role != models.Role.admin:
+        statement = statement.where(models.Trip.user_id == current_user.id)
+    if client:
+        statement = statement.where(models.Trip.client == client)
+    trips = session.exec(statement.order_by(models.Trip.start_time.desc())).all()
+    return schemas.TripCollection(trips=trips)

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,59 @@
+import enum
+from datetime import datetime
+from typing import List, Optional
+
+from sqlmodel import Field, Relationship, SQLModel
+
+
+class Role(str, enum.Enum):
+    admin = "admin"
+    user = "user"
+
+
+class TripType(str, enum.Enum):
+    business = "business"
+    personal = "personal"
+
+
+class UserVehicleLink(SQLModel, table=True):
+    user_id: Optional[int] = Field(default=None, foreign_key="user.id", primary_key=True)
+    vehicle_id: Optional[int] = Field(default=None, foreign_key="vehicle.id", primary_key=True)
+
+
+class User(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    username: str = Field(index=True, unique=True)
+    password_hash: str
+    role: Role = Field(default=Role.user)
+
+    vehicles: List["Vehicle"] = Relationship(back_populates="users", link_model=UserVehicleLink)
+    trips: List["Trip"] = Relationship(back_populates="user")
+
+
+class Vehicle(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str
+    client: Optional[str] = Field(default=None, index=True)
+    odometer_start: float = Field(default=0)
+
+    users: List[User] = Relationship(back_populates="vehicles", link_model=UserVehicleLink)
+    trips: List["Trip"] = Relationship(back_populates="vehicle")
+
+
+class Trip(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    vehicle_id: int = Field(foreign_key="vehicle.id")
+    user_id: int = Field(foreign_key="user.id")
+    start_time: datetime = Field(default_factory=datetime.utcnow)
+    end_time: Optional[datetime] = None
+    start_odometer: float
+    end_odometer: Optional[float] = None
+    start_lat: Optional[float] = None
+    start_lon: Optional[float] = None
+    end_lat: Optional[float] = None
+    end_lon: Optional[float] = None
+    trip_type: TripType = Field(default=TripType.business)
+    client: Optional[str] = Field(default=None, index=True)
+
+    vehicle: Vehicle = Relationship(back_populates="trips")
+    user: User = Relationship(back_populates="trips")

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,117 @@
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, Field, validator
+
+from app.models import Role, TripType
+
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+
+class TokenData(BaseModel):
+    username: str
+    role: Role
+    user_id: int
+
+
+class UserCreate(BaseModel):
+    username: str
+    password: str
+    role: Role = Role.user
+
+
+class UserRead(BaseModel):
+    id: int
+    username: str
+    role: Role
+
+    class Config:
+        orm_mode = True
+
+
+class VehicleCreate(BaseModel):
+    name: str
+    client: Optional[str] = None
+    odometer_start: float = 0
+
+
+class VehicleRead(BaseModel):
+    id: int
+    name: str
+    client: Optional[str]
+    odometer_start: float
+
+    class Config:
+        orm_mode = True
+
+
+class VehicleAssign(BaseModel):
+    user_id: int
+
+
+class OdometerUpdate(BaseModel):
+    odometer_start: float
+
+
+class TripBase(BaseModel):
+    vehicle_id: int
+    start_time: Optional[datetime] = None
+    start_odometer: Optional[float] = None
+    start_lat: Optional[float] = None
+    start_lon: Optional[float] = None
+    client: Optional[str] = None
+    trip_type: TripType = TripType.business
+
+
+class TripManualCreate(TripBase):
+    end_time: Optional[datetime] = None
+    end_odometer: float
+    end_lat: Optional[float] = None
+    end_lon: Optional[float] = None
+
+    @validator("end_odometer")
+    def positive(cls, value: float) -> float:
+        if value < 0:
+            raise ValueError("Odometer must be non-negative")
+        return value
+
+
+class TripStart(BaseModel):
+    vehicle_id: int
+    start_odometer: Optional[float] = None
+    start_lat: Optional[float] = None
+    start_lon: Optional[float] = None
+    client: Optional[str] = None
+    trip_type: TripType = TripType.business
+
+
+class TripStop(BaseModel):
+    end_odometer: float
+    end_lat: Optional[float] = None
+    end_lon: Optional[float] = None
+
+
+class TripRead(BaseModel):
+    id: int
+    vehicle_id: int
+    user_id: int
+    start_time: datetime
+    end_time: Optional[datetime]
+    start_odometer: float
+    end_odometer: Optional[float]
+    start_lat: Optional[float]
+    start_lon: Optional[float]
+    end_lat: Optional[float]
+    end_lon: Optional[float]
+    trip_type: TripType
+    client: Optional[str]
+
+    class Config:
+        orm_mode = True
+
+
+class TripCollection(BaseModel):
+    trips: List[TripRead]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.111.0
+uvicorn==0.30.1
+sqlmodel==0.0.16
+passlib[bcrypt]==1.7.4
+python-jose==3.3.0


### PR DESCRIPTION
## Summary
- add FastAPI application with JWT authentication, admin/user roles, and SQLite persistence
- implement vehicle management, odometer baseline updates, trip start/stop and manual logging with client filtering
- document setup instructions and available endpoints for the driving log API

## Testing
- python -m compileall app

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693846f3c5f08332a93b62a21d3f0aff)